### PR TITLE
Create instructor endpoint fixed 

### DIFF
--- a/courses/schemas/instructor_schemas.py
+++ b/courses/schemas/instructor_schemas.py
@@ -12,12 +12,12 @@ create_instructor_schema = AutoSchema(
             schema=coreschema.String(description="User's id who will be instructor"),
         ),
         coreapi.Field(
-            "course_id",
+            "course_alias",
             required=True,
             location="form",
-            type="integer",
+            type="string",
             schema=coreschema.String(
-                description="Course's id in which the user will be instructor"
+                description="Course's alias in which the user will be instructor"
             ),
         ),
         coreapi.Field(

--- a/courses/views/instructor_views.py
+++ b/courses/views/instructor_views.py
@@ -25,7 +25,7 @@ def create_instructor(request) -> JsonResponse:
     """
     try:
         User.objects.get(pk=request.data["user_id"])
-        Course.objects.get(pk=request.data["course_id"])
+        course: Course = Course.objects.get(alias=request.data["course_alias"])
 
         # verify if instructor_type is valid
         if request.data["instructor_type"] not in ["E", "T", "A"]:
@@ -33,10 +33,10 @@ def create_instructor(request) -> JsonResponse:
                 data={"message": "Invalid instructor type"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-
+        request.data["course_id"] = course.id
         # verify if already exists an instructor with this user_id and course_id
         if Instructor.objects.filter(
-            user_id=request.data["user_id"], course_id=request.data["course_id"]
+            user_id=request.data["user_id"], course_id=course.id
         ).exists():
             return JsonResponse(
                 data={"message": "This user is already instructor in this course"},
@@ -58,7 +58,7 @@ def create_instructor(request) -> JsonResponse:
         )
     except Course.DoesNotExist:
         return JsonResponse(
-            data={"message": "There is not a course with this id"},
+            data={"message": "There is not a course with this alias"},
             status=status.HTTP_404_NOT_FOUND,
         )
 


### PR DESCRIPTION
Before to create a instructor course's id was mandatory, now this action is carried out with course's alias rather than its id. 