### PR TITLE
Creating a material returns all Serializer data

### DIFF
--- a/courses/schemas/material_schemas.py
+++ b/courses/schemas/material_schemas.py
@@ -2,92 +2,94 @@ import coreapi
 import coreschema
 from rest_framework.schemas import AutoSchema
 
-create_material_schema = AutoSchema(manual_fields=[
-    coreapi.Field(
-        "module_id",
-        required=True,
-        location="form",
-        type="integer",
-        schema=coreschema.String(
-            description="Module's id from which you want to create the material")
-    ),
-    coreapi.Field(
-        "name",
-        required=True,
-        location="form",
-        type="string",
-        schema=coreschema.String(description="Material name")
-    ),
-    coreapi.Field(
-        "material_type",
-        required=True,
-        location="form",
-        type="string",
-        schema=coreschema.String(description="Material type")
-    ),
-    coreapi.Field(
-        "is_extra",
-        required=True,
-        location="form",
-        type="boolean",
-        schema=coreschema.String(description="Material is extra or not")
-    ),
-    coreapi.Field(
-        "order",
-        required=True,
-        location="form",
-        type="integer",
-        schema=coreschema.String(description="Material order")
-    )
-])
+create_material_schema = AutoSchema(
+    manual_fields=[
+        coreapi.Field(
+            "module_id",
+            required=True,
+            location="form",
+            type="integer",
+            schema=coreschema.String(
+                description="Module's id from which you want to create the material"
+            ),
+        ),
+        coreapi.Field(
+            "name",
+            required=True,
+            location="form",
+            type="string",
+            schema=coreschema.String(description="Material name"),
+        ),
+        coreapi.Field(
+            "material_type",
+            required=True,
+            location="form",
+            type="string",
+            schema=coreschema.String(description="Material type"),
+        ),
+        coreapi.Field(
+            "is_extra",
+            required=True,
+            location="form",
+            type="boolean",
+            schema=coreschema.String(description="Material is extra or not"),
+        ),
+    ]
+)
 
-get_material_schema = AutoSchema(manual_fields=[
-    coreapi.Field(
-        "material_id",
-        required=True,
-        location="path",
-        type="integer",
-        schema=coreschema.String(description="Material's id to get it")
-    ),
-])
+get_material_schema = AutoSchema(
+    manual_fields=[
+        coreapi.Field(
+            "material_id",
+            required=True,
+            location="path",
+            type="integer",
+            schema=coreschema.String(description="Material's id to get it"),
+        ),
+    ]
+)
 
-update_material_schema = AutoSchema(manual_fields=[
-    coreapi.Field(
-        "material_id",
-        required=True,
-        location="path",
-        type="integer",
-        schema=coreschema.String(description="Material's id to update it")
-    ),
-    coreapi.Field(
-        "name",
-        required=False,
-        location="form",
-        type="string",
-        schema=coreschema.String(description="New material name")
-    ),
-    coreapi.Field(
-        "material_type",
-        required=False,
-        location="form",
-        type="string",
-        schema=coreschema.String(description="New material type")
-    ),
-    coreapi.Field(
-        "is_extra",
-        required=False,
-        location="form",
-        type="boolean",
-        schema=coreschema.String(description="Material is extra or not")
-    ),
-])
+update_material_schema = AutoSchema(
+    manual_fields=[
+        coreapi.Field(
+            "material_id",
+            required=True,
+            location="path",
+            type="integer",
+            schema=coreschema.String(description="Material's id to update it"),
+        ),
+        coreapi.Field(
+            "name",
+            required=False,
+            location="form",
+            type="string",
+            schema=coreschema.String(description="New material name"),
+        ),
+        coreapi.Field(
+            "material_type",
+            required=False,
+            location="form",
+            type="string",
+            schema=coreschema.String(description="New material type"),
+        ),
+        coreapi.Field(
+            "is_extra",
+            required=False,
+            location="form",
+            type="boolean",
+            schema=coreschema.String(description="Material is extra or not"),
+        ),
+    ]
+)
 
-delete_material_schema = AutoSchema(manual_fields=[
-    coreapi.Field(
-        "material_id",
-        required=True,
-        location="path",
-        type="integer",
-        schema=coreschema.String(description="Material id")
-    ),
-])
+delete_material_schema = AutoSchema(
+    manual_fields=[
+        coreapi.Field(
+            "material_id",
+            required=True,
+            location="path",
+            type="integer",
+            schema=coreschema.String(description="Material id"),
+        ),
+    ]
+)

--- a/courses/views/material_views.py
+++ b/courses/views/material_views.py
@@ -33,9 +33,9 @@ def create_material(request) -> JsonResponse:
         serializer.save()
         # Update module's material counts
         update_count_created_material(serializer=serializer)
-        return JsonResponse(
-            {"message": "Material created successfully"}, status=status.HTTP_201_CREATED
-        )
+        response = serializer.data
+        response["message"] = "Material created successfully"
+        return JsonResponse(response, status=status.HTTP_201_CREATED)
 
     return JsonResponse(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 


### PR DESCRIPTION
The 'order' attribute is no longer needed in the /docs interactive endpoint when creating a new Material.